### PR TITLE
Add consistent-type-imports rule

### DIFF
--- a/node.js
+++ b/node.js
@@ -7,6 +7,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 12,
     sourceType: 'module',
+    project: './tsconfig.json',
   },
   plugins: [
     '@typescript-eslint',
@@ -216,6 +217,9 @@ module.exports = {
       'error',
     ],
     'yield-star-spacing': [
+      'error',
+    ],
+    '@typescript-eslint/consistent-type-imports': [
       'error',
     ],
   },


### PR DESCRIPTION
This is a good way to mitigate the likelihood of creating circular dependencies.